### PR TITLE
Fix a crash when turning off a specifig logging instance.

### DIFF
--- a/src/ngx_http_brokerlog_module.c
+++ b/src/ngx_http_brokerlog_module.c
@@ -279,7 +279,7 @@ ngx_http_brokerlog_handler(ngx_http_request_t *r)
         ngx_log_debug0(NGX_LOG_DEBUG_HTTP, log, 0, "brokerlog_zmq: handler() verify ZMQ socket");
         if (NULL == clecf->ctx->zmq_socket && 0 == clecf->ctx->screated) {
             ngx_log_debug0(NGX_LOG_INFO, log, 0, "brokerlog_zmq: handler() creating socket");
-            rc = zmq_create_socket(clecf);
+            rc = zmq_create_socket(pool, clecf);
             if (rc != 0) {
                 ngx_log_error(NGX_LOG_INFO, log, 0, "brokerlog_zmq: handler() error creating socket");
                 continue;

--- a/src/ngx_http_brokerlog_module.c
+++ b/src/ngx_http_brokerlog_module.c
@@ -451,7 +451,7 @@ ngx_http_brokerlog_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child)
             for (i = 0; i < conf->logs->nelts; i++) {
                 ngx_log_error(NGX_LOG_INFO, cf->log, 0, "brokerlog_zmq: merge_loc_conf() search %s match", eleconf[i].name->data);
                 if ((eleprev[j].name->len == eleconf[i].name->len)
-                        && ngx_strcmp(eleprev[j].name->data, eleconf[i].name->data) == 0)
+                        && ngx_strncmp(eleprev[j].name->data, eleconf[i].name->data, eleprev[j].name->len) == 0)
                 {
                    found = 1;
                    ngx_log_error(NGX_LOG_INFO, cf->log, 0, "brokerlog_zmq: merge_loc_conf() %s found", eleprev[j].name->data);
@@ -565,7 +565,7 @@ ngx_http_brokerlog_set_server(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         lecf = llcf->logs->elts;
         for (i = 0; i < llcf->logs->nelts; i++) {
             if (lecf[i].name->len == value[1].len
-                    && ngx_strcmp(lecf[i].name->data, value[1].data) == 0) {
+                    && ngx_strncmp(lecf[i].name->data, value[1].data, lecf[i].name->len) == 0) {
                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "brokerlog_server: target repeated");
                return NGX_CONF_ERROR;
             }
@@ -778,7 +778,7 @@ ngx_http_brokerlog_set_format(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
         for (i = 0; i < llcf->logs->nelts; i++) {
             clecf = ((ngx_http_brokerlog_element_conf_t *) llcf->logs->elts) + i;
             if ((clecf->name != NULL) && (clecf->name->len == value[1].len)
-                    && (ngx_strcmp(clecf->name->data, value[1].data) == 0)) {
+                    && (ngx_strncmp(clecf->name->data, value[1].data, clecf->name->len) == 0)) {
                found = 1;
                lecf = clecf;
                ngx_log_debug1(NGX_LOG_DEBUG_HTTP, log, 0, "brokerlog_zmq: set_format() found %V", &value[1]);
@@ -932,7 +932,7 @@ ngx_http_brokerlog_set_endpoint(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
             clecf = ((ngx_http_brokerlog_element_conf_t *) llcf->logs->elts) + i;
             /* we are literally searching for the name */
             if ((clecf->name != NULL) && (clecf->name->len == value[1].len)
-                    && (ngx_strcmp(clecf->name->data, value[1].data) == 0))
+                    && (ngx_strncmp(clecf->name->data, value[1].data, clecf->name->len) == 0))
             {
           found = 1;
           lecf = clecf;
@@ -1025,7 +1025,7 @@ ngx_http_brokerlog_set_off(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     ngx_http_brokerlog_loc_conf_t        *llcf = conf;
     ngx_http_brokerlog_element_conf_t    *lecf, *clecf;
     ngx_str_t                            *value;
-    ngx_uint_t                            i, found = 0;
+    ngx_uint_t                           i, found = 0;
 #if (NGX_DEBUG)
     ngx_log_t                            *log = cf->log;
 #endif
@@ -1035,7 +1035,7 @@ ngx_http_brokerlog_set_off(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
    */
     value = cf->args->elts;
 
-    if ((value[1].len == 3) && (ngx_strcmp(value[1].data, "all") == 0)) {
+    if ((value[1].len == 3) && (ngx_strncmp(value[1].data, "all", value[1].len) == 0)) {
         ngx_log_debug0(NGX_LOG_DEBUG_HTTP, log, 0, "brokerlog_zmq: set_off() ... all");
         llcf->off = 1;
         return NGX_CONF_OK;
@@ -1050,7 +1050,7 @@ ngx_http_brokerlog_set_off(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
             clecf = ((ngx_http_brokerlog_element_conf_t *) llcf->logs->elts) + i;
             /* we are literally searching for the name */
             if ((clecf->name != NULL) && (clecf->name->len == value[1].len)
-                    && (ngx_strcmp(clecf->name->data, value[1].data) == 0)) {
+                    && (ngx_strncmp(clecf->name->data, value[1].data, clecf->name->len) == 0)) {
                found = 1;
                lecf = clecf;
                ngx_log_debug1(NGX_LOG_DEBUG_HTTP, log, 0, "brokerlog_zmq: set_off() ... %V", &value[1]);

--- a/src/ngx_http_brokerlog_zmq.c
+++ b/src/ngx_http_brokerlog_zmq.c
@@ -133,7 +133,7 @@ zmq_term_ctx(ngx_http_brokerlog_ctx_t *ctx)
  * @warning It's important to look at here and define one socket per worker
  */
 int
-zmq_create_socket(ngx_http_brokerlog_element_conf_t *cf)
+zmq_create_socket(ngx_pool_t *pool, ngx_http_brokerlog_element_conf_t *cf)
 {
     int linger = ZMQ_NGINX_LINGER, rc = 0;
     uint64_t qlen = ZMQ_NGINX_QUEUE_LENGTH;
@@ -141,8 +141,8 @@ zmq_create_socket(ngx_http_brokerlog_element_conf_t *cf)
     char *connection;
 
     /* create a simple char * to the connection name */
-    connection = calloc(cf->server->connection->len + 1, sizeof(char));
-    memcpy(connection, cf->server->connection->data, cf->server->connection->len);
+    connection = ngx_pcalloc(pool, cf->server->connection->len + 1);
+    ngx_memcpy(connection, cf->server->connection->data, cf->server->connection->len);
 
     ngx_log_debug(NGX_LOG_DEBUG_HTTP, cf->ctx->log, 0, "ZMQ: zmq_create_socket() to %s", connection);
 
@@ -196,7 +196,7 @@ zmq_create_socket(ngx_http_brokerlog_element_conf_t *cf)
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, cf->ctx->log, 0, "ZMQ: zmq_create_socket() end");
 
     /* please, clean all your temporary variables */
-    free(connection);
+    ngx_pfree(pool, connection);
 
     /* if all was OK, we should return 0 */
     return rc;
@@ -227,8 +227,8 @@ brokerlog_serialize_zmq(ngx_pool_t *pool, ngx_str_t *endpoint, ngx_str_t *data, 
         return NGX_ERROR;
     }
 
-    memcpy(output->data, (const char *) endpoint->data, endpoint->len);
-    memcpy(output->data + endpoint->len, (const char *) data->data, data->len);
+    ngx_memcpy(output->data, (const char *) endpoint->data, endpoint->len);
+    ngx_memcpy(output->data + endpoint->len, (const char *) data->data, data->len);
 
     return NGX_OK;
 }

--- a/src/ngx_http_brokerlog_zmq.h
+++ b/src/ngx_http_brokerlog_zmq.h
@@ -54,7 +54,7 @@
 int zmq_init_ctx(ngx_http_brokerlog_ctx_t *ctx);
 void zmq_term_ctx(ngx_http_brokerlog_ctx_t *ctx);
 int zmq_create_ctx(ngx_http_brokerlog_element_conf_t *cf);
-int zmq_create_socket(ngx_http_brokerlog_element_conf_t *cf);
+int zmq_create_socket(ngx_pool_t *pool, ngx_http_brokerlog_element_conf_t *cf);
 ngx_int_t brokerlog_serialize_zmq(ngx_pool_t *pool, ngx_str_t *endpoint, ngx_str_t *payload, ngx_str_t *output);
 
 #endif


### PR DESCRIPTION
These commits change a few things, namely:
- Replace the use of `memcpy` and other memory-related functions with their `ngx_*` equivalents;
- Use `strncmp` instead of `strcmp` because nginx strings may not be null-terminated;
- Remove some redundant uses of `found` flags.

This ends up fixing the crash that happened when using `brokerlog_off` with a specific instance. I'm not so sure that the root cause of that bug was indeed fixed, though...
