### PR TITLE
qlen should be uint64_t type for ZMQ_HWM option

### DIFF
--- a/src/ngx_http_log_zmq.c
+++ b/src/ngx_http_log_zmq.c
@@ -137,8 +137,7 @@ int
 zmq_create_socket(ngx_pool_t *pool, ngx_http_log_zmq_element_conf_t *cf)
 {
     int linger = ZMQ_NGINX_LINGER, rc = 0;
-    int qlen = cf->qlen != ZMQ_NGINX_QUEUE_LENGTH ? cf->qlen : ZMQ_NGINX_QUEUE_LENGTH;
-
+    zmq_hwm_t qlen = cf->qlen < 0 ? ZMQ_NGINX_QUEUE_LENGTH : cf->qlen;
     char *connection;
 
     /* verify if we have a context created */

--- a/src/ngx_http_log_zmq.h
+++ b/src/ngx_http_log_zmq.h
@@ -39,9 +39,11 @@
 #define ZMQ_POLL_MSEC	1000
 #define ZMQ_SNDHWM		ZMQ_HWM
 #define	ZMQ_RCVHWM		ZMQ_HWM
+#define zmq_hwm_t uint64_t
 
 #else
 
+#define zmq_hwm_t int
 #define ZMQ_POLL_MSEC	1
 
 #endif


### PR DESCRIPTION
I found setopt for ZMQ_HWN failed in my error log, checking the api doc the value type should be uint64t.

http://api.zeromq.org/2-1:zmq-setsockopt
