### PR TITLE
add nginx-http-log-zmq as a Dynamic Module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ compiler:
 env:
   - VER_NGINX=1.6.3
   - VER_NGINX=1.8.1
+  - VER_NGINX=1.9.11
 
 before_install:
   - sudo apt-get update -qq
@@ -17,5 +18,7 @@ install:
 
   - cd "nginx-${VER_NGINX}"
   - ./configure --add-module=../..
+
+  - [ "${VER_NGINX}" = "1.9.11" ] && ./configure --add-dynamic-module=../..
 
 script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ compiler:
 
 env:
   - VER_NGINX=1.6.3
-  - VER_NGINX=1.8.0
+  - VER_NGINX=1.8.1
 
 before_install:
   - sudo apt-get update -qq

--- a/config
+++ b/config
@@ -25,18 +25,41 @@ if [ $ngx_found = no ]; then
 	exit 1
 fi
 
-ngx_addon_name=ngx_http_log_zmq_module
+ngx_addon_name="ngx_http_log_zmq_module"
 
 CORE_INCS="$CORE_INCS $ngx_feature_path $ngx_addon_dir/src"
 CORE_LIBS="$CORE_LIBS $ngx_feature_libs"
 
-HTTP_INCS="$HTTP_INCS $ngx_addon_dir/src $ngx_objs_dir"
-HTTP_MODULES="$HTTP_MODULES ngx_http_log_zmq_module"
+ZMQ_MODULE="$ngx_addon_name"
 
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS \
-				$ngx_addon_dir/src/ngx_http_log_zmq_module.c \
-				$ngx_addon_dir/src/ngx_http_log_zmq.c"
+ZMQ_SRCS="                                             \
+		  $ngx_addon_dir/src/ngx_http_log_zmq_module.c \
+		  $ngx_addon_dir/src/ngx_http_log_zmq.c        \
+		  "
 
-NGX_ADDON_DEPS="$NGX_ADDON_DEPS \
-				$ngx_addon_dir/src/ngx_http_log_zmq_module.h \
-				$ngx_addon_dir/src/ngx_http_log_zmq.h"
+ZMQ_DEPS="                                             \
+		  $ngx_addon_dir/src/ngx_http_log_zmq_module.h \
+		  $ngx_addon_dir/src/ngx_http_log_zmq.h        \
+		  "
+
+ngx_module_incs=$ngx_addon_dir
+ngx_module_deps=$ZMQ_DEPS
+ngx_module_libs=
+
+if [ "$ngx_module_link" = "DYNAMIC" ]; then
+	ngx_module_type=MISC
+	ngx_module_name="$ZMQ_MODULE"
+	ngx_module_srcs="$ZMQ_SRCS"
+
+	. auto/module
+
+elif [ "$ngx_module_link" = "YES" ]; then
+	ngx_module_type=HTTP
+	ngx_module_name="$ZMQ_MODULE"
+	ngx_module_incs=
+	ngx_module_deps=
+	ngx_module_srcs="$ZMQ_SRCS"
+
+	. auto/module
+
+fi


### PR DESCRIPTION
nginx 1.9.11 gives the opportunity to load modules dynamically.

This is a small adaptation for this new change.
