### PR TITLE
Hide build status (for now).

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It's asynchronous and only requires a small library.
 
 _This module is not distributed with the nginx source._ See the [installation instructions](#installation).
 
-[![Build Status](https://travis-ci.org/alticelabs/nginx-log-zmq.svg?branch=master)](https://travis-ci.org/alticelabs/nginx-log-zmq)
+<!--[![Build Status](https://travis-ci.org/alticelabs/nginx-log-zmq.svg?branch=master)](https://travis-ci.org/alticelabs/nginx-log-zmq)--->
 
 Table of Contents
 =================


### PR DESCRIPTION
The build is still on SAPO's account, so hide it for now.
