### PR TITLE
Fix module config for static builds on newer nginx versions

### DIFF
--- a/config
+++ b/config
@@ -53,7 +53,7 @@ if [ "$ngx_module_link" = "DYNAMIC" ]; then
 
 	. auto/module
 
-elif [ "$ngx_module_link" = "YES" ]; then
+elif [[ "$ngx_module_link" = "YES" || "$ngx_module_link" == "ADDON" ]]; then
 	ngx_module_type=HTTP
 	ngx_module_name="$ZMQ_MODULE"
 	ngx_module_incs=


### PR DESCRIPTION
Hello! This is a PR to update the module config file, so that nginx-log-zmq will build correctly against versions of NGINX as a static module. Currently, if one tries to build this module against latest nginx releases, the build will complete OK, but none of the nginx-log-zmq objects will get compiled and linked into nginx.

Thanks!